### PR TITLE
Seek return and pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pyright]
+typeCheckingMode = "standard"
+useLibraryCodeForTypes = true
+reportMissingTypeStubs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.pyright]
-typeCheckingMode = "standard"
+include = ["seekablehttpfile"]
+typeCheckingMode = "strict"
 useLibraryCodeForTypes = true
-reportMissingTypeStubs = false
+reportMissingTypeStubs = "warning"

--- a/seekablehttpfile/core.py
+++ b/seekablehttpfile/core.py
@@ -193,7 +193,7 @@ class SeekableHttpFile:
             assert self.etag is None
             self.etag = resp.etag
 
-    def seek(self, pos: int, whence: int = 0) -> None:
+    def seek(self, pos: int, whence: int = 0) -> int:
         LOG.debug(f"seek {pos} {whence}")
         # TODO clamp/error
         if whence == os.SEEK_SET:
@@ -204,6 +204,7 @@ class SeekableHttpFile:
             self.pos = self.length + pos
         else:
             raise ValueError(f"Invalid value for whence: {whence!r}")
+        return self.pos
 
     def tell(self) -> int:
         LOG.debug("tell")

--- a/seekablehttpfile/core.py
+++ b/seekablehttpfile/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
@@ -96,14 +98,14 @@ class SeekableHttpFile:
     ) -> None:
         self.url = url
         self.get_range = get_range
-        self.stats = {
+        self.stats: dict[str, int] = {
             "num_requests": 0,
             "optimistic_bytes_read": 0,
             "lazy_bytes_read": 0,
             "satisfied_from_cache": 0,
         }
-        self.pos = 0
-        self.length = -1
+        self.pos: int = 0
+        self.length: int = -1
         self.precache = precache
         self.check_etag = check_etag
         self.etag: Optional[str] = None
@@ -149,7 +151,7 @@ class SeekableHttpFile:
         assert resp.content_range is not None
         match = CONTENT_RANGE_RE.match(resp.content_range)
         assert match is not None, resp.content_range
-        start, end, length = match.groups()
+        start, _, length = match.groups()
         self.length = int(length)
         assert resp.content is not None
         self.end_cache = resp.content

--- a/seekablehttpfile/tests/core.py
+++ b/seekablehttpfile/tests/core.py
@@ -89,6 +89,7 @@ class SeekableHttpFileTest(unittest.TestCase):
 
     @unittest.skipIf(keke is None, "Keke is not installed")
     def test_smoke_keke(self) -> None:
+        assert keke is not None  # @skipIf above
         trace_output = io.StringIO()
         with keke.TraceOutput(file=trace_output, close_output_file=False):
             r = Fixture()

--- a/seekablehttpfile/tests/live.py
+++ b/seekablehttpfile/tests/live.py
@@ -76,6 +76,7 @@ class LiveTests(unittest.TestCase):
 
     @unittest.skipIf(keke is None, "Keke is not installed")
     def test_live_pypi_keke(self) -> None:
+        assert keke is not None  # @skipIf above
         trace_output = io.StringIO()
         with keke.TraceOutput(file=trace_output, close_output_file=False):
             f = SeekableHttpFile(SAMPLE_FILE)

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,11 @@ commands =
 depends =
     py{38,39,310,311,312,313,314}
 
+[testenv:typecheck]
+usedevelop = True
+deps = pyright
+commands = pyright
+
 [flake8]
 ignore = E203, E231, E266, E302, E501, W503
 max-line-length = 88


### PR DESCRIPTION
Two small quality-of-life changes, bundled since they came up together:

### `SeekableHttpFile.seek` returns the new position

Matches `io.IOBase.seek` semantics and makes `SeekableHttpFile` structurally
compatible with `zipfile._ZipReadable`, so callers can pass it to `ZipFile`
without a `type: ignore`.

### Add a `pyright` tox env

New `tox -e typecheck` runs `pyright` in standard mode (configured via
`pyproject.toml`). Narrowed `keke` `Optional` access in the two keke tests
with an `assert` under the existing `@skipIf` guard — no behavior change.
