### PR TITLE
Change check_etag default to False

### DIFF
--- a/seekablehttpfile/core.py
+++ b/seekablehttpfile/core.py
@@ -94,7 +94,7 @@ class SeekableHttpFile:
         url: str,
         get_range: Callable[..., GeneralizedResponse] = get_range_urlopen,
         precache: int = 256_000,
-        check_etag: bool = True,
+        check_etag: bool = False,
     ) -> None:
         self.url = url
         self.get_range = get_range

--- a/seekablehttpfile/tests/core.py
+++ b/seekablehttpfile/tests/core.py
@@ -185,7 +185,7 @@ class SeekableHttpFileTest(unittest.TestCase):
 
     def test_etag_changes(self) -> None:
         r = Fixture(etag="x")
-        f = SeekableHttpFile("", get_range=r.get_range, precache=0)
+        f = SeekableHttpFile("", get_range=r.get_range, precache=0, check_etag=True)
         f.read(1)
         r.etag = "y"
         with self.assertRaisesRegex(

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ dev =
     ufmt == 2.3.0
     usort == 1.0.7
     wheel == 0.42.0
+    pip  # for mypy --install-types
 test =
     coverage >= 6
 


### PR DESCRIPTION
This project is intended to be used on immutable files, and the check
was for extra safety.  However, the CDN used by files.pythonhosted.org
does not return consistent etags for range requests, and this ended up
being something that I would override every time I used this library.

It's now opt-in.